### PR TITLE
Prettier contour-labels, variable number of contour lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .Rproj.user
+.Rproj
 .Rhistory
 .RData
 .Ruserdata
+rsconnect/
+.gitignore

--- a/Shiny_carb_plot.Rmd
+++ b/Shiny_carb_plot.Rmd
@@ -64,14 +64,17 @@ inputPanel(
   selectInput(inputId = "parameter", 
               label = "dependent parameter",
               choices = c("ALK", "DIC", "fCO2", "fCO2insitu", "fCO2pot", 
-                          "HCO3", "OmegaAragonite", "OmegaCalcite", "pCO2", "pCO2insitu", "pCO2pot", "pH"))
+                          "HCO3", "OmegaAragonite", "OmegaCalcite", "pCO2", "pCO2insitu", "pCO2pot", "pH")),
+  sliderInput(inputId = "bins",
+              label = "number of bins in plot",
+              min = 3, max = 42, value = 11)
 )
 
 renderPlot({
   carb.data() %>%
     ggplot(aes_string(x = "co2", y = "co3", z = input$parameter)) +
-    geom_contour(size = 1) +
-    metR::geom_label_contour() +
+    geom_contour(size = 1, breaks = pretty(carb.data()[, input$parameter], n = input$bins)) +
+    metR::geom_label_contour(breaks = pretty(carb.data()[, input$parameter], n = input$bins)) +
     scale_x_continuous(expand = c(0, 0)) +
     scale_y_continuous(expand = c(0, 0)) +
     theme_light() +

--- a/Shiny_carb_plot.Rmd
+++ b/Shiny_carb_plot.Rmd
@@ -74,12 +74,13 @@ renderPlot({
   carb.data() %>%
     ggplot(aes_string(x = "co2", y = "co3", z = input$parameter)) +
     geom_contour(size = 1, breaks = pretty(carb.data()[, input$parameter], n = input$bins)) +
-    metR::geom_label_contour(breaks = pretty(carb.data()[, input$parameter], n = input$bins)) +
-    scale_x_continuous(expand = c(0, 0)) +
+    metR::geom_text_contour(breaks = pretty(carb.data()[, input$parameter], n = input$bins),
+                            rotate = TRUE, stroke = 0.3) +
+    #scale_x_continuous(expand = c(0, 0)) +
     scale_y_continuous(expand = c(0, 0)) +
-    theme_light() +
+    theme_minimal() +
     theme(text = element_text(size = 20))
-})
+}, width = 1000, height = 700)
 
 ```
 


### PR DESCRIPTION
there seems to be an erroneous selection of bins in the geom_label_contour() function, leading to un-pretty() labels in special cases (here: pH).

Manpages say: "Is best used with a previous call to ggplot2::stat_contour with the same parameters (e.g. the same binwidth, breaks, or bins)."

So I forced both, geom_label_contour() and geom_contour() to use the same (pretty()) breaks...